### PR TITLE
Fix defaultOptions undefined in plugin install

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import vueSelectSides from "./vue-select-sides.vue";
 
 function install(Vue, options) {
-  Vue.prototype.defaultOptions = options;
+  Vue.prototype.defaultOptions = options && options.constructor.name === "Object" ? options : {};
   if (install.installed) return;
   install.installed = true;
 }


### PR DESCRIPTION
Fixes #7 

When the plugin is used directly as a local component (as in the issue's [pen](https://codepen.io/hakanersu/pen/KKdjjzX) example) or is installed without passing `options`, `defaultOptions` is `undefined`.
We must ensure that the `defaultOptions` receives an object during the execution of the install function.

Check updated [pen ](https://codepen.io/acemir/pen/abNeazR) with a new build containing the fixes applied covering the expected behavior.

**Reproduction**
https://codepen.io/acemir/pen/abNeazR